### PR TITLE
fix: Add TLS support, and allow changing TLS backend.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -31,6 +31,7 @@ steps:
   cargo_clippy:
     image: *rust_image
     commands:
+      - apt update && apt install pkg-config libssl-dev -y
       - rustup component add clippy
       - cargo clippy --tests --all-targets -- -D warnings
     when:
@@ -39,6 +40,7 @@ steps:
   cargo_build:
     image: *rust_image
     commands:
+      - apt update && apt install pkg-config libssl-dev -y
       - cargo build
     when:
       - event: pull_request
@@ -48,6 +50,7 @@ steps:
     environment:
       RUST_BACKTRACE: "1"
     commands:
+      - apt update && apt install pkg-config libssl-dev -y
       - cargo test --no-fail-fast
     when:
       - event: pull_request

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ leptos = { version = "0.6", optional = true }
 serde_json = "1.0"
 
 [features]
-default = []
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 leptos = ["web-sys/AbortController", "dep:leptos"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
With the default features being disabled for the `reqwest` dependency in this commit https://github.com/LemmyNet/lemmy-client-rs/commit/398e498f458d9754d3bdc6f16714f561dfcb642e, a scheme error is raised by the request client when sending any request with `ClientOptions.secure` set to `true`. 

This enables TLS support by default and allows changing the backend via features.