### PR TITLE
Fix typos and repeated word

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,7 @@ HTTP PUT /comment/report/resolve"#
         list_comment_reports,
         ListCommentReports,
         ListCommentReportsResponse,
-        r#"Lists reports for comments in communities you moderate or instances you adminstrate.
+        r#"Lists reports for comments in communities you moderate or instances you administrate.
 
 HTTP GET /comment/report/list"#
     );
@@ -587,7 +587,7 @@ HTTP PUT /private_message/report/resolve"#
         list_private_message_reports,
         ListPrivateMessageReports,
         ListPrivateMessageReportsResponse,
-        r#"Lists reports of private messages received on the isntance you administrate.
+        r#"Lists reports of private messages received on the instance you administrate.
 
 HTTP GET /private_message/report/list"#
     );
@@ -667,7 +667,7 @@ HTTP POST /user/ban"#
         list_banned_users,
         (),
         BannedPersonsResponse,
-        r#"Gets users banned who are banned from your isntance.
+        r#"Gets users who are banned from your instance.
 
 HTTP GET /user/banned"#
     );
@@ -781,7 +781,7 @@ HTTP POST /user/leave_admin"#
         GenerateTotpSecretResponse,
         r#"Generates a secret to enable time-based one time passwords for two-factor authentication.
 
-After this, you will need to call /user/totp/update with a vaild token to enable it.
+After this, you will need to call /user/totp/update with a valid token to enable it.
 
 HTTP POST /user/totp/generate"#
     );
@@ -873,7 +873,7 @@ HTTP POST /admin/purge/community"#
         purge_post,
         PurgePost,
         SuccessResponse,
-        r#"Purges a post from the datbase.
+        r#"Purges a post from the database.
 
 HTTP POST /admin/purge/post"#
     );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,7 @@ pub struct ClientOptions {
     ///     secure: true
     /// };
     ///
-    /// // ✅ All you need is the domain (including subdomain, if applicaple).
+    /// // ✅ All you need is the domain (including subdomain, if applicable).
     /// let options = ClientOptions {
     ///     domain: String::from("lemmy.ml"),
     ///     secure: true


### PR DESCRIPTION
Noticed a typo when I was reading through the documentation, so I ran [`typos`](https://crates.io/crates/typos) and fixed the other ones that it found (plus a repeated word probably left over from a rewording).

`typos` also caught that `get_registration_aplication` is misspelled, but I left that alone since it would change the API.

https://github.com/LemmyNet/lemmy-client-rs/blob/c182880db95c6be709b4f51a1cc029ea7916416e/src/lib.rs#L832-L839

https://github.com/LemmyNet/lemmy-client-rs/blob/c182880db95c6be709b4f51a1cc029ea7916416e/src/lemmy_client_trait.rs#L592-L598